### PR TITLE
Fixed database integrity violation

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+brownbear-db9f1-firebase-key.json

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,15 @@
 const functions = require('firebase-functions')
 const admin = require('firebase-admin')
 const sha256 = require('js-sha256').sha256;
-admin.initializeApp()
 
 const cors = require('cors')({origin: true});
+
+var serviceAccount = require('./brownbear-db9f1-firebase-key.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  databaseURL: 'https://brownbear-db9f1.firebaseio.com'
+});
 
 exports.checkFlag = functions.region('asia-northeast1').https.onCall(data => {
   const ref = admin.firestore().collection('challenges').doc(data.chall_id)
@@ -22,14 +28,43 @@ exports.checkFlag = functions.region('asia-northeast1').https.onCall(data => {
 })
 
 exports.newSolve = functions.region('asia-northeast1').https.onCall(data => {
-  const ref = admin.firestore().collection('challenges').doc(data.chall_id)
-  return ref.update({
-    solvers: admin.firestore.FieldValue.increment(1)
-  }).then(() => {
-    admin.firestore().collection('users').doc(data.user_handle).update({
-      points: admin.firestore.FieldValue.increment(data.chall_point)
-    }).catch(err => console.log(err))
-  })
+  let status = "success"
+  let points = 0
+
+  admin.firestore().collection('solved').where("user","==",data.user_handle).get().then(docs => {
+    if (!docs.empty) {
+      let length = docs._size
+      let cnt = 0;
+      docs.forEach(doc => {
+        cnt++
+        admin.firestore().collection('challenges').doc(doc.data().chall).get()
+        .then(solvedChall => {
+          points += solvedChall.data().points
+          if (cnt == length) {
+            admin.firestore().collection('users').doc(data.user_handle).update({
+              points: points
+            })
+          }
+        })
+      })
+    }
+  }).catch(err => {console.log(err); status="error"})
+
+  admin.firestore().collection('solved').where("chall","==",data.chall_id)
+  .get()
+  .then(docs => {
+    let solvers_num = docs._size - 1
+    if (docs.empty) {
+      solvers_num = 0
+    } 
+    else {
+      admin.firestore().collection('challenges').doc(data.chall_id).update({
+        solvers: solvers_num+1
+      })
+    }
+  }).catch(err => {console.log(err); status="error"})
+
+  return { status: status }
 })
 
 exports.addSolver = functions.region('asia-northeast1').https.onCall(data => {

--- a/src/components/challenge/Archive.vue
+++ b/src/components/challenge/Archive.vue
@@ -117,27 +117,25 @@ export default {
       checkFlag({ flag: this.input_flag, chall_id: chall.id })
         .then(res => {
           if(res.data.correct) {
-            let newSolve = functions.httpsCallable('newSolve')
-            newSolve({ chall_id: chall.id, chall_point: chall.points, user_handle: this.profile })
-              .then(() => {
-                let addSolver = functions.httpsCallable('addSolver')
-                addSolver({ user_handle: this.profile, chall_id: chall.id, doc_id: this.profile+':'+chall.id })
-                  .then(res => {
-                    if(!res.malicious) {
-                      this.loading = false
-                      this.input_flag = ""
-                      this.snackbar = true
-                      chall.solved = true
-                      chall.solvers += 1
-                    } else {
-                      this.loading = false
-                      this.input_flag = "Don't try something woopy"
-                    }
-                  })
-              })
+            let addSolver = functions.httpsCallable('addSolver')
+            addSolver({ user_handle: this.profile, chall_id: chall.id, doc_id: this.profile+':'+chall.id })
+              .then((res) => {
+                if(!res.malicious) {
+                  this.loading = false
+                  this.input_flag = ""
+                  this.snackbar = true
+                  chall.solved = true
+                  chall.solvers += 1
+                  let newSolve = functions.httpsCallable('newSolve')
+                  newSolve({ user_handle: this.profile, chall_id: chall.id })
+              } else {
+                  this.loading = false
+                  this.input_flag = "Don't try something woopy"
+              }
+            })
           } else {
-            this.loading = false
-            this.alert = true
+              this.loading = false
+              this.alert = true
           }
         })
     }

--- a/src/components/challenge/InHouse.vue
+++ b/src/components/challenge/InHouse.vue
@@ -117,23 +117,21 @@ export default {
       checkFlag({ flag: this.input_flag, chall_id: chall.id })
         .then(res => {
           if(res.data.correct) {
-            let newSolve = functions.httpsCallable('newSolve')
-            newSolve({ chall_id: chall.id, chall_point: chall.points, user_handle: this.profile })
-              .then(() => {
-                let addSolver = functions.httpsCallable('addSolver')
-                addSolver({ user_handle: this.profile, chall_id: chall.id, doc_id: this.profile+':'+chall.id })
-                  .then(res => {
-                    if(!res.malicious) {
-                      this.loading = false
-                      this.input_flag = ""
-                      this.snackbar = true
-                      chall.solved = true
-                      chall.solvers += 1
-                    } else {
-                      this.loading = false
-                      this.input_flag = "Don't try something woopy"
-                    }
-                  })
+            let addSolver = functions.httpsCallable('addSolver')
+            addSolver({ user_handle: this.profile, chall_id: chall.id, doc_id: this.profile+':'+chall.id })
+              .then(res => {
+                if(!res.malicious) {
+                  this.loading = false
+                  this.input_flag = ""
+                  this.snackbar = true
+                  chall.solved = true
+                  chall.solvers += 1
+                  let newSolve = functions.httpsCallable('newSolve')
+                  newSolve({ user_handle: this.profile, chall_id: chall.id, })
+                } else {
+                  this.loading = false
+                  this.input_flag = "Don't try something woopy"
+                }
               })
           } else {
             this.loading = false


### PR DESCRIPTION
flag submit 시 엔터를 연타하는 경우 점수가 반복적으로 오르는 버그가 있었습니다.
이를 수정하기 위해 newSolve 함수 내용을 point의 증가가 아닌
solved 컬렉션에서 유저가 푼 문제 목록을 확인한 뒤 점수를 업데이트하는 방식으로 변경했습니다.
이를 위해 solved 컬렉션에 유저가 푼 문제를 추가하는 addSolver을 newSolve보다 먼저 실행 하도록 Archive.vue, InHouse.vue를 수정했습니다.
처리속도가 많이 느려지긴 했지만 현재 cykor 회원들만 사이트를 이용중이라는 점 감안하면 큰 문제 없을 것이고
데이터베이스 무결성 보존에도 더 좋을 것 같다고 판단했습니다.
패치에 앞서 먼저 말씀을 나눠보아야하지만 현재 신입생들이 이 사이트를 이용한 과제 중에 있고 
이 버그를 알아낸 친구들이 있어서 급하게 패치했습니다 ㅠㅠ
 